### PR TITLE
[wip] Add a workflow to run clang-format and push back the changes

### DIFF
--- a/.github/scripts/run-clang-format.py
+++ b/.github/scripts/run-clang-format.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import sys
+import subprocess
+
+from identify import identify
+
+
+def get_output_lines(cmd):
+    """Get the output from the cmd"""
+    return (
+        f
+        for f in subprocess.run(cmd, capture_output=True).stdout.decode().split("\n")
+        if f
+    )
+
+
+def get_repo_files():
+    """Get all files of the current repository as a list assuming this is run at
+    the repo root"""
+    return get_output_lines(["git", "ls-files"])
+
+
+def get_cpp_files(all_files):
+    """Return a generator expression that only contains the c++ files"""
+    for f in all_files:
+        # Filter out files that are inputs for config steps
+        if ".in." not in f and "c++" in identify.tags_from_path(f):
+            yield f
+
+
+def run_clang_format(files):
+    """Run clang-format on all passed files"""
+    return subprocess.run(
+        ["clang-format-12", "-i", "--style=file"] + list(files)
+    ).returncode
+
+
+def get_changed_files():
+    """Get all files that changed"""
+    return get_output_lines(["git", "diff", "--name-only"])
+
+
+if __name__ == "__main__":
+    cpp_files = get_cpp_files(get_repo_files())
+    run_clang_format(cpp_files)
+    for f in get_changed_files():
+        print(f"Formatted {f}")

--- a/.github/workflows/fix-clang-format.yml
+++ b/.github/workflows/fix-clang-format.yml
@@ -1,0 +1,52 @@
+name: Run clang-format and commit fixes
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  fix-clang-format:
+    # Only makes sense on PRs here and we also immediately filter out any other
+    # comments than "/fix-style"
+    if: ${{ github.event.issue.pull_request }} && startsWith(github.event.comment.body, '/fix-style')
+    runs-on:
+      ubuntu-latest
+
+    permissions:
+      pull-requests: write
+      contents: write
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Post confirmation comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Since this is triggered by an "issue_comment" we take the PR number
+          # from the triggering "issue"
+          gh pr comment ${{ github.event.issue.number }} --body "Let me try to fix that for you"
+      - name: Checkout PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr checkout ${{ github.event.issue.number }}
+          # We commit as the user who triggered the workflow
+          git config --global user.email ${{ github.event.comment.user.login }}@github.com
+          git config --global user.name ${{ github.event.comment.user.login }}
+      - uses: cvmfs-contrib/github-action-cvmfs@v3
+      - name: Run clang-format
+        run: |
+          source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh
+          pip install identify
+          python .github/scripts/run-clang-format.py
+      - name: Commit changes
+        run: |
+          git add $(git diff --name-only)
+          git commit -m "[format] Run clang-format"
+      - name: Push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push


### PR DESCRIPTION
This is a working draft for a workflow that runs `clang-format -i` and then pushes back the fixes on a PR when prompted via `/fix-style` in a comment of the PR.

This is all "handrolled", there are actions that could be used to achieve the same
- https://github.com/DoozyX/clang-format-lint-action
- https://github.com/EndBug/add-and-commit

Depending on how much control we want to have over the environment in which we run this we could probably replace quite a bit of this with those. In the end we mainly need to be consistent with what we run in the `pre-commit` workflow in the repository.

- [ ] Graceful exit in case there are no changes