### PR TITLE
Add -Wno-dangling-reference when using GCC

### DIFF
--- a/defaults/cmake/Key4hepConfig.cmake
+++ b/defaults/cmake/Key4hepConfig.cmake
@@ -9,7 +9,7 @@ macro(key4hep_set_compiler_flags)
   if(CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
     set(COMPILER_FLAGS "${COMPILER_FLAGS} -Winconsistent-missing-override -Wheader-hygiene -fcolor-diagnostics")
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(COMPILER_FLAGS "${COMPILER_FLAGS} -fdiagnostics-color=always")
+    set(COMPILER_FLAGS "${COMPILER_FLAGS} -fdiagnostics-color=always -Wno-dangling-reference")
   endif()
 
   if (DEFINED KEY4HEP_SET_COMPILER_FLAGS AND NOT KEY4HEP_SET_COMPILER_FLAGS)


### PR DESCRIPTION
After the inclusion of GCC 14 in the stack, some warnings have appeared when calling some functions in DD4hep that return const &. From what I understand, in these cases this warning is a false positive because the compiler doesn't have access to the implementation of the functions so it can't know there isn't a dangling reference to a temporary (after all the warning only says "possibly").  I suggest removing it. There is also a way of suppressing the warnings in DD4hep with attributes, but then all the affected functions would need it and that can be easily overlooked after adding or changing one while also making the code uglier. This is one example of the warning: 

``` 
/k4geo/detectorCommon/src/DetUtils_k4geo.cpp:480:15: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
  480 |   const auto& transformMatrix = detelement.nominal().worldTransformation();
      |               ^~~~~~~~~~~~~~~
/k4geo/detectorCommon/src/DetUtils_k4geo.cpp:480:73: note: the temporary was destroyed at the end of the full expression 'detelement.dd4hep::DetElement::nominal().dd4hep::Alignment::worldTransformation()'
  480 |   const auto& transformMatrix = detelement.nominal().worldTransformation();
```


Since this is breaking CI in some places (because of `-Werror`), I'll merge and push the changes soon if there aren't any complains.