### PR TITLE
Include packages from HEP-FCC

### DIFF
--- a/scripts/get_packages.sh
+++ b/scripts/get_packages.sh
@@ -17,7 +17,7 @@ packages=(
 
     # HEP-FCC
     "k4reccalorimeter"
-    "fccanalyses"
+    # "fccanalyses"
     "dual-readout"
     "k4gen"
     "k4simgeant4"

--- a/scripts/get_packages.sh
+++ b/scripts/get_packages.sh
@@ -1,4 +1,5 @@
 packages=(
+    # Key4hep
     "edm4hep"
     "k4clue"
     "k4edm4hep2lcioconv"
@@ -13,4 +14,12 @@ packages=(
     "CLDConfig"
     "k4gaudipandora"
     # "key4hep-tutorials"
+
+    # HEP-FCC
+    "k4reccalorimeter"
+    "fccanalyses"
+    "dual-readout"
+    "k4gen"
+    "k4simgeant4"
     )
+


### PR DESCRIPTION
Since I'm going to make some changes to the images, now it would be a good time to add the configuration used in Key4hep to HEP-FCC packages. I have identified the ones I would say this applies to. After doing this the packages in the list will get:
- A workflow for building on top of the latest release and nightlies, using the available images (already existing in some repositories, but wouldn't receive
  updates if not included in this list)
- A file Key4hepConfig.cmake with default configuration (will require a PR to tell cmake to use this file)
- A default .clang-format

And possibly in the future more common things that are discussed in an issue or pull repository.

Tagging @kjvbrt and @BrieucF