### PR TITLE
Add a default ruleset for Github and a script to update it

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ called `sync-files.sh` and will pick up all the repositories in
 `get_packages.sh` (currently all the ones with `CMakeLists.txt` that are not
 archived).
 
+## Github rulesets
+
+To update the github rulesets for many repositories run
+`scripts/update-ruleset-all.sh`. To update the default ruleset used the easiest
+way is to create one in Github, export it and then overwrite the json file
+`defaults/github/default-branch-ruleset.json`.
+
 # Running the tests
 
 ## Troubleshooting

--- a/defaults/github/default-branch-ruleset.json
+++ b/defaults/github/default-branch-ruleset.json
@@ -1,0 +1,82 @@
+{
+  "id": 3880683,
+  "name": "Default branch (Key4hep)",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "jmcarcell/EDM4hep",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "automatic_copilot_code_review_enabled": false,
+        "allowed_merge_methods": [
+          "squash",
+          "rebase"
+        ]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "build (nightly, alma9, key4hep)",
+            "integration_id": 15368
+          },
+          {
+            "context": "build (nightly, ubuntu22, key4hep)",
+            "integration_id": 15368
+          },
+          {
+            "context": "build (nightly, ubuntu24, key4hep)",
+            "integration_id": 15368
+          },
+          {
+            "context": "build (release, alma9, key4hep)",
+            "integration_id": 15368
+          },
+          {
+            "context": "build (release, ubuntu22, key4hep)",
+            "integration_id": 15368
+          },
+          {
+            "context": "pre-commit",
+            "integration_id": 15368
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/scripts/update-ruleset-all.sh
+++ b/scripts/update-ruleset-all.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# This script is used to update rulesets for all packages in 
+# all the repositories in /key4hep-dev-utils/scripts/get_packages.sh
+
+# Usage example:
+# ./update-ruleset-all.sh
+
+SCRIPT_DIR=$(dirname "$0")
+source $SCRIPT_DIR/get_packages.sh
+
+destination=$2
+files_to_sync=("${@:3}")
+for package_name in "${packages[@]}"; do
+    $SCRIPT_DIR/update-ruleset.sh $package_name
+done

--- a/scripts/update-ruleset-all.sh
+++ b/scripts/update-ruleset-all.sh
@@ -6,6 +6,8 @@
 # Usage example:
 # ./update-ruleset-all.sh
 
+set -e
+
 SCRIPT_DIR=$(dirname "$0")
 source $SCRIPT_DIR/get_packages.sh
 

--- a/scripts/update-ruleset.sh
+++ b/scripts/update-ruleset.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# This script is used to update rulesets a single repository on Github
+
+# Usage example:
+# ./update-ruleset.sh organization/repo
+
 set -e
 
 repo=$1

--- a/scripts/update-ruleset.sh
+++ b/scripts/update-ruleset.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+repo=$1
+
+# The name has to match the one in the ruleset file
+id=$(gh api \
+  -H "Accept: application/vnd.github+json" \
+  /repos/$repo/rulesets | jq '.[] | select(.name == "Default branch (Key4hep)") | .id')
+
+if [ -z "$id" ]; then
+  echo "No default branch ruleset found"
+else
+  gh api \
+    --method DELETE \
+    -H "Accept: application/vnd.github+json" \
+    /repos/$repo/rulesets/$id
+fi
+
+out=$(gh api\
+  --method POST \
+  -H "Accept: application/vnd.github+json" \
+  /repos/$repo/rulesets \
+  --input ../defaults/github/default-branch-ruleset.json)
+
+echo "Added default branch ruleset to $repo"


### PR DESCRIPTION
In the process of centralizing common stuff, this PR adds a default ruleset and a script to update it. This is meant to homogeinize which CI workflows are run, requirements to merge and related CI settings.

We currently have a mix of the default branch protection rules and rulesets in some repos. The default branch protection rules are fine, but they are simply less flexible - for example, they can't be set from the command line while the rulesets can. So rulesets are preferred. The existing issue is that doing something like changing the name of the build workflows will invalidate existing requirements on the existing workflows, since the old ones don't exist anymore (they still appear as required) and the new ones are not required until updated, see for example . This also will solve the very annoying task of having to update each repository every time a new OS is added or removed.

<img src="https://github.com/user-attachments/assets/b7e07c81-a4d8-4e9d-9baf-77fe255d3a28" width="400">

How this will work: a ruleset for the default branch is pushed to most of the repositories in Key4hep (more below about what this one does).
- For further customizations the "old" branch protection rules can be used. Some repositories have workflows that are not in others. They can be enabled in the branch protection rules and then both the ones in the branch protection rules and in the ruleset will be required. For everything I tested, every setting that is enabled either in the branch protection rules or in the ruleset will be applied.
- Another annoying topic is that after releases become old then the build workflow on top of the latest release does not work in some repos. The answer for this would be to disable it in the ruleset, which would then be overwritten at some point. I think this is OK for now since it doesn't happen for every repo (the alternative is parsing the current rule and not adding the release workflows if they are not there).

Contents of the default ruleset:

- Bypass list: repo admins (otherwise not even the bypass button is enabled for admins)
- Target branch: the default branch however it is called
- Restrict deletions
- Require linear history
- Require a pull request before merging
  - Require conversation resolution before merging
  - Allowed merge methods: squash, rebase
- Require status checks to pass
  - Require branches to be up to date before merging
  - Status checks: release, nightly builds and pre-commit
  - Block force pushes