### PR TITLE
Remove Ubuntu22 from the default ruleset

### DIFF
--- a/defaults/github/default-branch-ruleset.json
+++ b/defaults/github/default-branch-ruleset.json
@@ -49,19 +49,11 @@
             "integration_id": 15368
           },
           {
-            "context": "build (nightly, ubuntu22, key4hep)",
-            "integration_id": 15368
-          },
-          {
             "context": "build (nightly, ubuntu24, key4hep)",
             "integration_id": 15368
           },
           {
             "context": "build (release, alma9, key4hep)",
-            "integration_id": 15368
-          },
-          {
-            "context": "build (release, ubuntu22, key4hep)",
             "integration_id": 15368
           },
           {


### PR DESCRIPTION
I have just updated the default ruleset in many repositories not to require Ubuntu 22 since there is no CI for those builds anymore.