### PR TITLE
Update gitignore to add a podio section and packages that have moved

### DIFF
--- a/defaults/.gitignore
+++ b/defaults/.gitignore
@@ -233,6 +233,10 @@ pyrightconfig.json
 # Key4hep
 spack-*
 install/
+## podio
+podio_generated_files.cmake
+/include/podio/podioVersion.h
+/python/podio/__init__.py
 ## EDM4hep
 /python/edm4hep/__version__.py
 edm4hep/edm4hep/

--- a/scripts/get_packages.sh
+++ b/scripts/get_packages.sh
@@ -14,12 +14,13 @@ packages=(
     "key4hep/CLDConfig"
     "key4hep/k4gaudipandora"
     # "key4hep-tutorials"
+    "key4hep/k4generatorsconfig"
+    "key4hep/k4mljettagger"
+    "key4hep/k4simgeant4"
+    "key4hep/k4gen"
 
     # HEP-FCC
     "hep-fcc/k4reccalorimeter"
-    #"hep-fcc/fccanalyses"
-    "hep-fcc/dual-readout"
-    "hep-fcc/k4gen"
-    "key4hep/k4simgeant4"
+    # "hep-fcc/fccanalyses"
     )
 


### PR DESCRIPTION
The podio section is in EDM4hep and I didn't want to delete it. Some packages have moved from HEP-FCC to Key4hep. After this is merged, I'll update all the repositories in the list to add the new .gitignore.