### PR TITLE
Ensure that the embedded RPATHs point to the libs

### DIFF
--- a/defaults/cmake/Key4hepConfig.cmake
+++ b/defaults/cmake/Key4hepConfig.cmake
@@ -71,11 +71,15 @@ macro(key4hep_set_rpath)
   elseif(DEFINED KEY4HEP_SET_RPATH AND NOT KEY4HEP_SET_RPATH)
     set(CMAKE_SKIP_INSTALL_RPATH TRUE)           # skip the full RPATH for the install tree
   else()
-    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}") # install directory for libraries
+    set(_lib_dir "${CMAKE_INSTALL_LIBDIR}")
+    if(NOT _lib_dir)
+      set(_lib_dir "lib")
+    endif()
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${_lib_dir}") # install directory for libraries
     # the RPATH to be used when installing, but only if it's not a system directory
-    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" isSystemDir)
+    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/${_lib_dir}" isSystemDir)
     if("${isSystemDir}" STREQUAL "-1")
-      set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+      set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${_lib_dir}")
     endif()
   endif()
 endmacro()

--- a/defaults/cmake/Key4hepConfig.cmake
+++ b/defaults/cmake/Key4hepConfig.cmake
@@ -62,7 +62,7 @@ macro(key4hep_set_rpath)
   # Check whether to add RPATH to the installation (the build tree always has the RPATH enabled)
   if(APPLE)
     set(CMAKE_INSTALL_NAME_DIR "@rpath")
-    set(CMAKE_INSTALL_RPATH "@loader_path/../lib")    # self relative LIBDIR
+    set(CMAKE_INSTALL_RPATH "@loader_path/../lib")    # self relative to library
     # the RPATH to be used when installing, but only if it's not a system directory
     list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
     if("${isSystemDir}" STREQUAL "-1")
@@ -71,11 +71,11 @@ macro(key4hep_set_rpath)
   elseif(DEFINED KEY4HEP_SET_RPATH AND NOT KEY4HEP_SET_RPATH)
     set(CMAKE_SKIP_INSTALL_RPATH TRUE)           # skip the full RPATH for the install tree
   else()
-    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIBDIR}") # install LIBDIR
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}") # install directory for libraries
     # the RPATH to be used when installing, but only if it's not a system directory
-    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" isSystemDir)
     if("${isSystemDir}" STREQUAL "-1")
-      set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIBDIR}")
+      set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
     endif()
   endif()
 endmacro()


### PR DESCRIPTION
`LIBDIR` is empty / unset and the embedded `RPATH` will only point to the install prefix. That in turn might result in symbol lookup errors or library mismatches in environments where one builds several versions of a package, because some parts of the environment (e.g. `LD_LIBRARY_PATH`) could point to an incompatible version of a dependency library.


BEGINRELEASENOTES
- Ensure that the embedded `RPATH` points to the `<prefix>/lib[64]` directory after installation

ENDRELEASENOTES
