### PR TITLE
Ignore remnants from k4RecTracker tests

### DIFF
--- a/defaults/.gitignore
+++ b/defaults/.gitignore
@@ -246,6 +246,11 @@ test/k4FWCoreTest/**/*.root
 ## k4MarlinWrapper
 test/inputFiles
 test/gaudi_opts/testConverterConstants.py
+## k4RecTracker
+DCHdigi/test/test_DCHdigi/*.root
+Tracking/test/**/*.root
+Tracking/test/testTrackFinder/SteeringFile_IDEA_o1_v03.py
+DataAlgFORGEANT.root
 
 # AI tools
 .claude/


### PR DESCRIPTION
BEGINRELEASENOTES
- Add remnants from `k4RecTracker` tests to `defaults/.gitignore`

ENDRELEASENOTES
